### PR TITLE
Bump xunit.runner.console from 2.8.1 to 2.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="xunit.runner.console" Version="2.8.1">
+    <PackageVersion Include="xunit.runner.console" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>


### PR DESCRIPTION
Bumps xunit.runner.console from 2.8.1 to 2.9.0.

---
updated-dependencies:
- dependency-name: xunit.runner.console dependency-type: direct:production update-type: version-update:semver-minor ...